### PR TITLE
Add command-line wrapper for Pyxelate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Once installed, Pyxelate can be used either from the command line or from Python
 ```bash
 $ pyxelate examples/blazkowicz.jpg output.png --factor 14 --palette 7
 Pyxelating examples/blazkowicz.jpg...
-open output.pntWrote output.png
+Wrote output.png
 ```
 
 Use `pyxelate --help` for a full list of command-line options, which map onto the

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Super Pyxelate converts images to 8-bit pixel art. It is an improved, faster imp
 
 # Usage
 
+Once installed, Pyxelate can be used either from the command line or from Python.
+
+```bash
+$ pyxelate examples/blazkowicz.jpg output.png --factor 14 --palette 7
+Pyxelating examples/blazkowicz.jpg...
+open output.pntWrote output.png
+```
+
+Use `pyxelate --help` for a full list of command-line options, which map onto the
+Python arguments described below.
+
+Invoking from Python:
+
 ```python
 from skimage import io
 from pyxelate import Pyx, Pal
@@ -132,7 +145,6 @@ Preprocessing and color space conversion tricks are also applied for better resu
 - Dithering takes time (especially *atkinson*) as they are mostly implemented in plain python with loops.
 ![You look like a good pixel](/examples/p_br2.png)
 ## TODOs
-- Add CLI tool for Pyxelate so images can be batch converted from command line.
 - Re-implement Pyxelate for animations / sequence of frames in video.
 - Include PIPENV python environment files instead of just setup.py.
 - Implement Yliluoma's ordered dithering algorithm and experiment with improving visuals through gamma correction. 

--- a/pyxelate/main.py
+++ b/pyxelate/main.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+from typing import List, Optional, Set, Tuple, Union
+
+from skimage import io
+from . import Pyx, Pal
+
+
+def convert(args: argparse.Namespace):
+    pyx = Pyx(
+        height=args.height,
+        width=args.width,
+        factor=args.factor,
+        upscale=args.upscale,
+        depth=args.depth,
+        palette=args.palette,
+        dither=args.dither,
+        sobel=args.sobel,
+        alpha=args.alpha,
+        boost=not args.noboost,
+    )
+    image = io.imread(args.INFILE)
+    pyx.fit(image)
+    new_image = pyx.transform(image)
+    io.imsave(args.OUTFILE, new_image)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("INFILE", type=str, help="Input image filename.")
+    parser.add_argument("OUTFILE", type=str, help="Output image filename.")
+    parser.add_argument("--width", type=int, help="Output image width.", default=None)
+    parser.add_argument("--height", type=int, help="Output image height.", default=None)
+    parser.add_argument("--factor", type=int, help="Downsample factor.", default=1)
+    parser.add_argument(
+        "--upscale", type=int, help="Upscale factor for output pixels.", default=1
+    )
+    parser.add_argument(
+        "--depth", type=int, help="Number of times to downscale.", default=1
+    )
+    parser.add_argument(
+        "--palette",
+        type=str,
+        help="Number of colors in output palette, or a palette name. "
+        f"Valid choices are: {list(Pal.__members__)}",
+        default="8",
+    )
+    parser.add_argument(
+        "--dither",
+        type=str,
+        help="Type of dithering to use.",
+        default="none",
+        choices=["none", "naive", "bayer", "floyd", "atkinson"],
+    )
+    parser.add_argument(
+        "--sobel", type=int, help="Size of the Sobel operator.", default=3
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        help="Alpha threshold for output pixel visibility.",
+        default=0.6,
+    )
+    parser.add_argument(
+        "--noboost",
+        action="store_true",
+        help="By default, adjust contrast and apply preprocessing on the image before "
+        "transformation for better results. In case you see unwanted dark "
+        "pixels in your image, use --noboost.",
+    )
+    parser.add_argument("--quiet", action="store_true", help="Suppress logging output.")
+    args = parser.parse_args()
+
+    # The --palette arg can be an integer or a palette name.
+    try:
+        palette = int(args.palette)
+    except ValueError:
+        try:
+            palette = Pal[args.palette]
+        except KeyError:
+            print(f"Bad value for --palette: {args.palette}")
+            print(f"Valid choices are: {list(Pal.__members__)}")
+            parser.print_usage()
+            sys.exit(1)
+    args.palette = palette
+
+    if not args.quiet:
+        print(f"Pyxelating {args.INFILE}...")
+
+    convert(args)
+
+    if not args.quiet:
+        print(f"Wrote {args.OUTFILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyxelate/pyx.py
+++ b/pyxelate/pyx.py
@@ -111,7 +111,7 @@ class Pyx(BaseEstimator, TransformerMixin):
                  alpha=.6, boost=True):
         if (width is not None or height is not None) and factor is not None:
             raise ValueError("You can only set either height + width or the downscaling factor, but not both!")
-        assert height is None or height >= 1, "Width must be a positive integer!"
+        assert height is None or height >= 1, "Height must be a positive integer!"
         assert width is None or width >= 1, "Width must be a positive integer!" 
         assert factor is None or factor >= 1, "Factor must be a positive integer!"
         assert isinstance(sobel, int) and sobel >= 2, "Sobel must be an integer strictly greater than 1!"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="pyxelate",
-    version="2.0.3",
+    version="2.0.4",
     description="Pyxelate is a Python class that converts images into 8-bit pixel art.",
     url="http://github.com/sedthh/pyxelate",
     author="sedthh",

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,19 @@
 
 from setuptools import setup
 
-setup(name='pyxelate',
-      version='2.0.3',
-      description='Pyxelate is a Python class that converts images into 8-bit pixel art.',
-      url='http://github.com/sedthh/pyxelate',
-      author='sedthh',
-      license='MIT',
-      packages=['pyxelate'],
-      zip_safe=False,
-      install_requires=[
-          'scikit-learn>=0.24.1', 'scikit-image>=0.18.1','numba>=0.53.1'
-      ],
-      )
+setup(
+    name="pyxelate",
+    version="2.0.3",
+    description="Pyxelate is a Python class that converts images into 8-bit pixel art.",
+    url="http://github.com/sedthh/pyxelate",
+    author="sedthh",
+    license="MIT",
+    packages=["pyxelate"],
+    zip_safe=False,
+    install_requires=["scikit-learn>=0.24.1", "scikit-image>=0.18.1", "numba>=0.53.1"],
+    entry_points={
+        "console_scripts": [
+            "pyxelate = pyxelate.main:main",
+        ],
+    },
+)


### PR DESCRIPTION
This PR adds a small wrapper around Pyxelate which can be invoked with the "pyxelate" command once installed.

Example usage:
```
$ pyxelate input.jpg output.png --factor 10 --palette PICO_8
```

Here is the full help message:
```
$ pyxelate --help
usage: pyxelate [-h] [--width WIDTH] [--height HEIGHT] [--factor FACTOR]
                [--upscale UPSCALE] [--depth DEPTH] [--palette PALETTE]
                [--dither {none,naive,bayer,floyd,atkinson}] [--sobel SOBEL]
                [--alpha ALPHA] [--noboost] [--quiet]
                INFILE OUTFILE

positional arguments:
  INFILE                Input image filename.
  OUTFILE               Output image filename.

optional arguments:
  -h, --help            show this help message and exit
  --width WIDTH         Output image width.
  --height HEIGHT       Output image height.
  --factor FACTOR       Downsample factor.
  --upscale UPSCALE     Upscale factor for output pixels.
  --depth DEPTH         Number of times to downscale.
  --palette PALETTE     Number of colors in output palette, or a palette name.
                        Valid choices are: ['TELETEXT', 'BBC_MICRO',
                        'CGA_MODE4_PAL1', 'CGA_MODE5_PAL1', 'CGA_MODE4_PAL2',
                        'ZX_SPECTRUM', 'APPLE_II_LO', 'APPLE_II_HI',
                        'COMMODORE_64', 'GAMEBOY_COMBO_UP',
                        'GAMEBOY_COMBO_DOWN', 'GAMEBOY_COMBO_LEFT',
                        'GAMEBOY_COMBO_RIGHT', 'GAMEBOY_A_UP',
                        'GAMEBOY_A_DOWN', 'GAMEBOY_A_LEFT', 'GAMEBOY_A_RIGHT',
                        'GAMEBOY_B_UP', 'GAMEBOY_B_DOWN', 'GAMEBOY_B_LEFT',
                        'GAMEBOY_B_RIGHT', 'GAMEBOY_ORIGINAL',
                        'GAMEBOY_POCKET', 'GAMEBOY_VIRTUALBOY',
                        'MICROSOFT_WINDOWS_16', 'MICROSOFT_WINDOWS_20',
                        'MICROSOFT_WINDOWS_PAINT', 'PICO_8', 'MSX',
                        'MONO_OBRADINN_IBM', 'MONO_OBRADINN_MAC', 'MONO_BJG',
                        'MONO_BW', 'MONO_PHOSPHOR_AMBER',
                        'MONO_PHOSPHOR_LTAMBER', 'MONO_PHOSPHOR_GREEN1',
                        'MONO_PHOSPHOR_GREEN2', 'MONO_PHOSPHOR_GREEN3',
                        'MONO_PHOSPHOR_APPLE', 'APPLE_II_MONO',
                        'MONO_PHOSPHOR_APPLEC', 'APPLE_II_MONOC']
  --dither {none,naive,bayer,floyd,atkinson}
                        Type of dithering to use.
  --sobel SOBEL         Size of the Sobel operator.
  --alpha ALPHA         Alpha threshold for output pixel visibility.
  --noboost             By default, adjust contrast and apply preprocessing on
                        the image before transformation for better results. In
                        case you see unwanted dark pixels in your image, use
                        --noboost.
  --quiet               Suppress logging output.
```

