### PR TITLE
CLI fix and code cleanup

### DIFF
--- a/pyxelate/__init__.py
+++ b/pyxelate/__init__.py
@@ -1,11 +1,10 @@
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 __short_description__ = (
     "Downsample images to 8-bit pixel art.",
 )
 __license__ = "MIT"
 __author__ = "Richard Nagyfi"
-__author_email__ = "sedthh@gmail.com"
 __github_username__ = "sedthh"
 
 from .pal import Pal

--- a/pyxelate/main.py
+++ b/pyxelate/main.py
@@ -88,7 +88,7 @@ def main():
     parser.add_argument("OUTFILE", type=str, help="Output image filename. For sequence of images use: folder/output_%%d.png")
     parser.add_argument("--width", type=int, help="Output image width.", default=None)
     parser.add_argument("--height", type=int, help="Output image height.", default=None)
-    parser.add_argument("--factor", type=int, help="Downsample factor.", default=1)
+    parser.add_argument("--factor", type=int, help="Downsample factor.", default=None)
     parser.add_argument(
         "--upscale", type=int, help="Upscale factor for output pixels.", default=1
     )
@@ -152,9 +152,9 @@ def main():
     parser.add_argument(
         "--keyframe", 
         type=float, 
-        default=.33,
+        default=.3,
         help="Percentage (0. - 1.) of average image difference needed to be considered a new keyframe."
-        "Default value is 0.33. Only works for animations with --sequence."
+        "Default value is 0.30. Only works for animations with --sequence."
     )
     parser.add_argument(
         "--sensitivity", 

--- a/pyxelate/pyx.py
+++ b/pyxelate/pyx.py
@@ -323,7 +323,7 @@ class Pyx(BaseEstimator, TransformerMixin):
 
     def _svd(self, X):
         """Reconstruct image via truncated SVD on each RGB channel"""
-        if self.SVD_N_COMPONENTS >= X.shape[0] and self.SVD_N_COMPONENTS >= X.shape[1]:
+        if self.SVD_N_COMPONENTS >= X.shape[0] - 1 and self.SVD_N_COMPONENTS >= X.shape[1] - 1:
             return X  # skip SVD
                 
         @adapt_rgb(each_channel)

--- a/pyxelate/vid.py
+++ b/pyxelate/vid.py
@@ -1,18 +1,12 @@
 import numpy as np
 from skimage.morphology import square as skimage_square
 from skimage.morphology import binary_dilation as skimage_dilation
-from skimage.filters import gaussian
-from scipy.ndimage import uniform_filter
 
 
 class Vid:
     """Generator class that yields new images based on differences between them"""
     
-    SVD_N_COMPONENTS = 32
-    SVD_MAX_ITER = 16
-    SVD_RANDOM_STATE = 1234
-    
-    def __init__(self, images, pad=0, sobel=2, keyframe=.33, sensitivity=.1):
+    def __init__(self, images, pad=0, sobel=2, keyframe=.3, sensitivity=.1):
         assert isinstance(images, (list, tuple)), "Function only accepts list or tuple of image representations!"
         self.images = images
         if pad is None or pad == 0:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="pyxelate",
-    version="2.1.0",
+    version="2.1.1",
     description="Pyxelate is a Python class that converts images into 8-bit pixel art.",
     url="http://github.com/sedthh/pyxelate",
     author="sedthh",


### PR DESCRIPTION
- default vid keyframe value is now .3 instead of .33
- CLI factor deafults to None
- removed unneeded code from vid
- pyx svd will be skipped if n_components >= shape - 1
- udpated version number