### PR TITLE
Support newer versions of Python

### DIFF
--- a/pyxelate/__init__.py
+++ b/pyxelate/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.2"
+__version__ = "2.2.0"
 
 __short_description__ = (
     "Downsample images to 8-bit pixel art.",

--- a/pyxelate/pyx.py
+++ b/pyxelate/pyx.py
@@ -42,7 +42,7 @@ class BGM(BayesianGaussianMixture):
     MAX_ITER = 128
     RANDOM_STATE = 1234567
     
-    def __init__(self, palette: Union[int, BasePalette], find_palette: bool, xp=None) -> None:
+    def __init__(self, palette: Union[int, BasePalette], find_palette: bool) -> None:
         """Init BGM with different default parameters depending on use-case"""
         self.palette = palette
         self.find_palette = find_palette
@@ -67,7 +67,7 @@ class BGM(BayesianGaussianMixture):
             # start centroid search from the palette's values
             self.mean_prior = np.mean([val[0] for val in self.palette], axis=0)
     
-    def _initialize_parameters(self, X: np.ndarray, random_state: int) -> None:
+    def _initialize_parameters(self, X: np.ndarray, random_state: int, xp=None) -> None:
         """Changes init parameters from K-means to CIE LAB distance when palette is assigned"""
         assert self.init_params == "kmeans", "Initialization is overwritten, can only be set as 'kmeans'."
         n_samples, _ = X.shape

--- a/pyxelate/pyx.py
+++ b/pyxelate/pyx.py
@@ -12,7 +12,7 @@ from skimage.color import rgb2hsv, hsv2rgb, rgb2lab, deltaE_ciede2000
 from skimage.exposure import equalize_adapthist
 from skimage.filters import sobel as skimage_sobel
 from skimage.filters import median as skimage_median
-from skimage.morphology import square as skimage_square
+from skimage.morphology import footprint_rectangle as skimage_square
 from skimage.morphology import dilation as skimage_dilation
 from skimage.transform import resize
 from skimage.util import view_as_blocks
@@ -42,7 +42,7 @@ class BGM(BayesianGaussianMixture):
     MAX_ITER = 128
     RANDOM_STATE = 1234567
     
-    def __init__(self, palette: Union[int, BasePalette], find_palette: bool) -> None:
+    def __init__(self, palette: Union[int, BasePalette], find_palette: bool, xp=None) -> None:
         """Init BGM with different default parameters depending on use-case"""
         self.palette = palette
         self.find_palette = find_palette
@@ -288,7 +288,7 @@ class Pyx(BaseEstimator, TransformerMixin):
         @adapt_rgb(each_channel)
         def _wrapper(channel):
             # apply to each channel
-            return skimage_dilation(channel, footprint=skimage_square(3))
+            return skimage_dilation(channel, footprint=skimage_square([3,3]))
         
         h, w, d = X.shape
         X_ = self._pad(X, 3)
@@ -303,7 +303,7 @@ class Pyx(BaseEstimator, TransformerMixin):
         @adapt_rgb(each_channel)
         def _wrapper(channel):
             # apply to each channel
-            return skimage_median(channel, skimage_square(3))
+            return skimage_median(channel, skimage_square([3,3]))
         
         h, w, d = X.shape
         X_ = self._pad(X, 3)  # add padding for median filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=0.24.1
-scikit-image>=0.19.1
+scikit-learn>=1.8.0
+scikit-image>=0.26.0
 numba>=0.53.1
 matplotlib


### PR DESCRIPTION
I was unable to get the project working with Python 3.14.2, I think d/t support for 3.9 being dropped in newer versions of scikit-learn and/or scikit-image. I'm using pyxelate as a dependency in my own project and wanted to support newer versions of Python, so I poked around and was able to get it working with a few minor changes.

I realize this is an old project, and I won't pretend that all of the ML stuff isn't miles above my head, so I don't expect this to be merged. But I figured it'd be nice to at least share :)